### PR TITLE
valheim: set `createHome` for valheim user

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -113,6 +113,7 @@ in {
         isSystemUser = true;
         group = "valheim";
         home = stateDir;
+        createHome = true;
       };
       groups.valheim = {};
     };


### PR DESCRIPTION
I meant to contribute this for a while, just got reminded when I reworked my server flake for 23.11.
When I initially added this module, I needed to set `createHome`, so adding it in the module itself might make sense.