### PR TITLE
Update valheim server to 0.217.38 and export it from the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,10 @@
     pkgsFor = system:
       import nixpkgs {
         inherit system;
-        overlays = [steam-fetcher.overlays.default];
+        overlays = [
+          steam-fetcher.overlays.default
+          self.overlays.default
+        ];
       };
     lintersFor = system: let
       pkgs = pkgsFor system;
@@ -72,5 +75,10 @@
       valheim-bepinex-pack = final.callPackage ./pkgs/bepinex-pack {};
       fetchValheimThunderstoreMod = final.callPackage ./pkgs/build-support/fetch-thunderstore-mod {};
     };
+    packages = forAllSystems (system: let
+      pkgs = pkgsFor system;
+    in {
+      valheim-server = pkgs.valheim-server;
+    });
   };
 }

--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation rec {
   name = "valheim-server";
-  version = "0.217.31";
+  version = "0.217.38";
   src = fetchSteam {
     inherit name;
     appId = "896660";
     depotId = "896661";
-    manifestId = "8373574482301544279";
-    hash = "sha256-u1+7fkDbmQuuiSVNHYaycWwKfEt7qE8kVeU5lsDnUKQ=";
+    manifestId = "252049227837324070";
+    hash = "sha256-Ulm0MvuqK/tgpQC4seznhPdQRW6qc0ImVtaxfuFsXrw=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.


### PR DESCRIPTION
Title says it all, I updated the valheim package to 0.217.38 and exported it from the flake to make it easier to build directly (`nix build ".#valheim-server"`).