### PR TITLE
Pin fetchSteam to inputs.steam-fetcher (and update bepinex and valheim-server).

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ Then in your `configuration.nix`,
 }
 ```
 
-## valheim-server or steamworks-sdk-redist hash missmatch
-
-valheim-server uses steam-fetcher which in turn uses, depotdownloader to fetch Steam packages from the Steam Depot. It's been noticed that depotdownloader produces different hashes between different versions of nixpkgs. If you're encountering issues and have set `inputs.nixpkgs.follows` for this flake, try removing that. The overlays explicitly use the nixpkgs from this flakes input for steam-fetcher.
+## `valheim-server` or `steamworks-sdk-redist` hash missmatch
+`valheim-server` uses [`steam-fetcher`](https://github.com/nix-community/steam-fetcher) which in turn uses DepotDownloader to fetch Steam packages from the Steam Depot.  DepotDownloader may produce different results between different versions of DepotDownloader for the exact same depot.  If you get an error about a hash mismatch on and have set `nixpkgs.follows` for this flake input, try removing that.  The overlays explicitly use the nixpkgs from this flake input for `steam-fetcher` to avoid this problem.
 
 ## Notes on using mods
 Because BepInEx (the mod framework used by just about every Valheim mod) must both be installed in-tree with Valheim, and to be able to write to various files in the directory tree, we cannot run the modded Valheim server from the Nix store.  To work around this without completely giving up on immutability, we copy the files out of the Nix store to a directory under `/var/lib/valheim` and run from there, but wipe and rebuild this directory on each launch.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,8 @@ Add this flake as an input, and add the NixOS module.  Your config should look s
 ```nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
-    valheim-server = {
-      url = "github:aidalgol/valheim-server-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    valheim-server.url = "github:aidalgol/valheim-server-flake";
   };
   outputs = {
     self,
@@ -73,6 +70,10 @@ Then in your `configuration.nix`,
   # ...
 }
 ```
+
+## valheim-server or steamworks-sdk-redist hash missmatch
+
+valheim-server uses steam-fetcher which in turn uses, depotdownloader to fetch Steam packages from the Steam Depot. It's been noticed that depotdownloader produces different hashes between different versions of nixpkgs. If you're encountering issues and have set `inputs.nixpkgs.follows` for this flake, try removing that. The overlays explicitly use the nixpkgs from this flakes input for steam-fetcher.
 
 ## Notes on using mods
 Because BepInEx (the mod framework used by just about every Valheim mod) must both be installed in-tree with Valheim, and to be able to write to various files in the directory tree, we cannot run the modded Valheim server from the Nix store.  To work around this without completely giving up on immutability, we copy the files out of the Nix store to a directory under `/var/lib/valheim` and run from there, but wipe and rebuild this directory on each launch.

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694424148,
-        "narHash": "sha256-1PV7sxioWWD/yLxnkLVOL6zvlTOBl98kUv4ol4p0ozo=",
+        "lastModified": 1713389119,
+        "narHash": "sha256-uVJbXj52X7OibwSqnmkByWjMVqYsAbVdtK3X+0a0tCM=",
         "owner": "nix-community",
         "repo": "steam-fetcher",
-        "rev": "2033f99c7aee506f5af18026a3cab1c93bd0439f",
+        "rev": "e5a28494b600df98e63f5160432fae36c727501e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,16 +69,21 @@
       valheim = import ./nixos-modules/valheim.nix {inherit self steam-fetcher;};
       default = valheim;
     };
-    overlays.default = final: prev: {
-      valheim-server-unwrapped = final.callPackage ./pkgs/valheim-server {};
+
+    overlays.default = final: prev: let
+      pkgs = pkgsFor final.system;
+    in {
+      valheim-server-unwrapped = final.callPackage ./pkgs/valheim-server {inherit (pkgs) fetchSteam;};
       valheim-server = final.callPackage ./pkgs/valheim-server/fhsenv.nix {};
       valheim-bepinex-pack = final.callPackage ./pkgs/bepinex-pack {};
       fetchValheimThunderstoreMod = final.callPackage ./pkgs/build-support/fetch-thunderstore-mod {};
     };
+
     packages = forAllSystems (system: let
       pkgs = pkgsFor system;
     in {
-      valheim-server = pkgs.valheim-server;
+      inherit (pkgs) valheim-server;
+      inherit (pkgs) valheim-bepinex-pack;
     });
   };
 }

--- a/pkgs/bepinex-pack/default.nix
+++ b/pkgs/bepinex-pack/default.nix
@@ -6,15 +6,15 @@
 }:
 stdenv.mkDerivation {
   name = "BepInExPack-Valheim";
-  version = "5.4.2105";
+  version = "5.4.2202";
 
   # While BepInEx is open-source, there are no publicly available steps for
   # reproducing the BepInEx Valheim pack.
   src = fetchValheimThunderstoreMod {
     owner = "denikson";
     name = "BepInExPack_Valheim";
-    version = "5.4.2105";
-    hash = "sha256-V9xrjWmpKVmNIAAm4NlKOv8s9b6Tl3RsqDdLXyTYqDQ=";
+    version = "5.4.2202";
+    hash = "sha256-wI66hX6T7SWNsXJ3xO7/S5OqCsbz0pSNcQGBB2Q4e3c=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.
@@ -30,7 +30,6 @@ stdenv.mkDerivation {
       BepInExPack_Valheim/BepInEx \
       BepInExPack_Valheim/doorstop_config.ini \
       BepInExPack_Valheim/doorstop_libs \
-      BepInExPack_Valheim/unstripped_corlib \
       BepInExPack_Valheim/winhttp.dll \
       $out
 

--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation rec {
   name = "valheim-server";
-  version = "0.217.38";
+  version = "0.217.46";
   src = fetchSteam {
     inherit name;
     appId = "896660";
     depotId = "896661";
-    manifestId = "252049227837324070";
-    hash = "sha256-Ulm0MvuqK/tgpQC4seznhPdQRW6qc0ImVtaxfuFsXrw=";
+    manifestId = "8203628659808204648";
+    hash = "sha256-vC48nevn6iuu5zWDciHLW+41OwyBI0q1eDeOPnBdFPE=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.


### PR DESCRIPTION
Same idea as https://github.com/nix-community/steam-fetcher/pull/3

This explicitly sets `steam-fetcher` in the overlays to be that of this flakes inputs, as that `steam-fetcher` is following this flakes `nixpkgs` then it won't use the overlayed nixpkgs depot downloader but this flakes nixpkgs.

I also updated bepinex and valheim server while I was at it. I can split the MR for those if you prefer.