### PR TITLE
Add admin-, permitted-, and bannedlist.txt

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -166,8 +166,8 @@ in {
             ${lib.concatMapStrings (id: "${id}\n") cfg.adminList}
             EOF
             chown -R valheim:valheim ${stateDir}/.config
-          '';
-          lib.optionalString (cfg.bepinexMods != []) ''
+          ''
+          + lib.optionalString (cfg.bepinexMods != []) ''
             if [ -e ${installDir} ]; then
               chmod -R +w ${installDir}
               rm -rf ${installDir}

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -75,7 +75,10 @@ in {
     adminList = lib.mkOption {
       type = with lib.types; listOf str;
       default = [];
-      example = [];
+      example = [
+        "72057602627862526"
+        "72057602627862527"
+      ];
       description = lib.mdDoc ''
         List of Steam IDs to be added to the adminlist.txt file.
 
@@ -86,7 +89,10 @@ in {
     permittedList = lib.mkOption {
       type = with lib.types; listOf str;
       default = [];
-      example = [];
+      example = [
+        "72057602627862526"
+        "72057602627862527"
+      ];
       description = lib.mdDoc ''
         List of Steam IDs to be added to the permittedlist.txt file.
 
@@ -98,7 +104,10 @@ in {
     bannedList = lib.mkOption {
       type = with lib.types; listOf str;
       default = [];
-      example = [];
+      example = [
+        "72057602627862526"
+        "72057602627862527"
+      ];
       description = lib.mdDoc ''
         List of Steam IDs to be added to the bannedlist.txt file.
 

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -191,8 +191,8 @@ in {
               done
             '';
           createListFile = name: list: ''
-              echo "// List of Steam IDs for ${name} ONE per line" > ${stateDir}/.config/unity3d/IronGate/Valheim/${name}
-              ${lib.concatMapStrings (id: "echo '${id}' >> ${stateDir}/.config/unity3d/IronGate/Valheim/${name}\n") list}
+              echo "// List of Steam IDs for ${name} ONE per line
+              ${lib.strings.concatStringsSep "\n" list}" > ${stateDir}/.config/unity3d/IronGate/Valheim/${name}
               chown valheim:valheim ${stateDir}/.config/unity3d/IronGate/Valheim/${name}
             '';
         in

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -157,15 +157,15 @@ in {
                 cp $cfg $out/$(stripHash $cfg)
               done
             '';
+          createListFile = name: list: ''
+              echo "// List of Steam IDs for ${name} ONE per line" > ${stateDir}/.config/unity3d/IronGate/Valheim/${name}
+              ${lib.concatMapStrings (id: "echo '${id}' >> ${stateDir}/.config/unity3d/IronGate/Valheim/${name}\n") list}
+              chown valheim:valheim ${stateDir}/.config/unity3d/IronGate/Valheim/${name}
+            '';
         in
-          lib.optionalString (cfg.adminList != []) ''
-            # Create adminlist.txt
+          ''
             mkdir -p ${stateDir}/.config/unity3d/IronGate/Valheim
-            cat > ${stateDir}/.config/unity3d/IronGate/Valheim/adminlist.txt <<EOF
-            // List admin players ID  ONE per line
-            ${lib.concatMapStrings (id: "${id}\n") cfg.adminList}
-            EOF
-            chown -R valheim:valheim ${stateDir}/.config/unity3d/IronGate/Valheim/adminlist.txt
+            ${createListFile "adminlist.txt" cfg.adminList}
           ''
           + lib.optionalString (cfg.bepinexMods != []) ''
             if [ -e ${installDir} ]; then

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -78,7 +78,31 @@ in {
       example = [];
       description = lib.mdDoc ''
         List of Steam IDs to be added to the adminlist.txt file.
+
         These users will have admin privileges on the server.
+      '';
+    };
+
+    permittedList = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [];
+      example = [];
+      description = lib.mdDoc ''
+        List of Steam IDs to be added to the permittedlist.txt file.
+
+        Only these users will be allowed to join the server if the list is not empty.
+        If you use this, all players not on the list will be unable to join.
+      '';
+    };
+    
+    bannedList = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [];
+      example = [];
+      description = lib.mdDoc ''
+        List of Steam IDs to be added to the bannedlist.txt file.
+
+        These users will be banned from the server.
       '';
     };
 
@@ -166,6 +190,8 @@ in {
           ''
             mkdir -p ${stateDir}/.config/unity3d/IronGate/Valheim
             ${createListFile "adminlist.txt" cfg.adminList}
+            ${createListFile "permittedlist.txt" cfg.permittedList}
+            ${createListFile "bannedlist.txt" cfg.bannedList}
           ''
           + lib.optionalString (cfg.bepinexMods != []) ''
             if [ -e ${installDir} ]; then

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -165,7 +165,7 @@ in {
             // List admin players ID  ONE per line
             ${lib.concatMapStrings (id: "${id}\n") cfg.adminList}
             EOF
-            chown -R valheim:valheim ${stateDir}/.config
+            chown -R valheim:valheim ${stateDir}/.config/unity3d/IronGate/Valheim/adminlist.txt
           ''
           + lib.optionalString (cfg.bepinexMods != []) ''
             if [ -e ${installDir} ]; then

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -72,6 +72,16 @@ in {
       '';
     };
 
+    adminList = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [];
+      example = [];
+      description = lib.mdDoc ''
+        List of Steam IDs to be added to the adminlist.txt file.
+        These users will have admin privileges on the server.
+      '';
+    };
+
     bepinexMods = lib.mkOption {
       type = with lib; types.listOf types.package;
       default = [];
@@ -148,6 +158,15 @@ in {
               done
             '';
         in
+          lib.optionalString (cfg.adminList != []) ''
+            # Create adminlist.txt
+            mkdir -p ${stateDir}/.config/unity3d/IronGate/Valheim
+            cat > ${stateDir}/.config/unity3d/IronGate/Valheim/adminlist.txt <<EOF
+            // List admin players ID  ONE per line
+            ${lib.concatMapStrings (id: "${id}\n") cfg.adminList}
+            EOF
+            chown -R valheim:valheim ${stateDir}/.config
+          '';
           lib.optionalString (cfg.bepinexMods != []) ''
             if [ -e ${installDir} ]; then
               chmod -R +w ${installDir}


### PR DESCRIPTION
Adds the following _voluntary_ options

```nix
services.valheim = {
  #...
  adminList = [
    "76521191055385553"
    "76551295065884553"
  ];
  permittedList = [
    "76521191055385553"
    "76551295065884553"
  ];
  bannedList = [
    "76521191055385553"
    "76551295065884553"
  ];
}
```
Note: these will always override the `adminlist.txt`, `permittedlist.txt`, and `bannedlist.txt` in `/var/lib/valheim/.config/unity3d/IronGate/Valheim`.

Also, the examples in the option descriptions do not link to any known steamIDs.

Resolves #11 