### PR TITLE
Add public, logFile and preset flags

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -85,6 +85,16 @@ in {
       '';
     };
 
+    preset = lib.mkOption {
+      type = lib.types.str; nullOr str;
+      default = null;
+      example = "hardcore";
+      description = lib.mdDoc ''
+        The preset world modifier, valid options are
+        "easy", "hard", "hardcore", "casual", "hammer" and "immersive".
+      '';
+    };
+
     password = lib.mkOption {
       type = lib.types.str;
       default = "";
@@ -251,6 +261,7 @@ in {
               ]
               ++ (lib.lists.optional cfg.crossplay "-crossplay")
               ++ (lib.lists.optional (cfg.logFile != null) "-logFile \"${cfg.logFile}\"")
+              ++ (lib.lists.optional (cfg.preset != null) "-preset \"${cfg.preset}\"")
         };
       };
     };

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -315,7 +315,7 @@ in {
               ]
               ++ (lib.lists.optional cfg.crossplay "-crossplay")
               ++ (lib.lists.optional (cfg.logFile != null) "-logFile \"${cfg.logFile}\"")
-              ++ (lib.lists.optional (cfg.preset != null) "-preset \"${cfg.preset}\"")
+              ++ (lib.lists.optional (cfg.preset != null) "-preset \"${cfg.preset}\""));
         };
       };
     };

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -61,6 +61,16 @@ in {
       description = lib.mdDoc "Whether to open ports in the firewall.";
     };
 
+    public = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Toggles visibility on the Steam server & community lists.
+        When not set, defaults to true (visible).
+        Set to false to make the server private.
+      '';
+    };
+
     password = lib.mkOption {
       type = lib.types.str;
       default = "";
@@ -223,8 +233,9 @@ in {
               ++ [
                 "-port \"${builtins.toString cfg.port}\""
                 "-password \"${cfg.password}\""
+                "-public ${if cfg.public then "1" else "0"}"
               ]
-              ++ (lib.lists.optional cfg.crossplay "-crossplay"));
+              ++ (lib.lists.optional cfg.crossplay "-crossplay")
         };
       };
     };

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -75,13 +75,16 @@ in {
     logFile = lib.mkOption {
       type = with lib.types; nullOr str;
       default = null;
-      example = "/var/log/valheim-server.log";
+      example = "/var/lib/valheim/log/valheim-server.log";
       description = lib.mdDoc ''
         The path where the server log file will be saved.
 
         When set, this will redirect all logs from stdout to the specified path.
         This means that the logs will not be captured by systemd's journal.
         Leave this option unset to keep console logging enabled.
+
+        Make sure the valheim user has write access to the specified directory, otherwise
+        the valheim service fail to start and exit.
       '';
     };
 

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -86,7 +86,7 @@ in {
     };
 
     preset = lib.mkOption {
-      type = lib.types.str; nullOr str;
+      type = lib.types; nullOr str;
       default = null;
       example = "hardcore";
       description = lib.mdDoc ''

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -86,7 +86,7 @@ in {
     };
 
     preset = lib.mkOption {
-      type = lib.types; nullOr str;
+      type = with lib.types; nullOr str;
       default = null;
       example = "hardcore";
       description = lib.mdDoc ''

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -66,8 +66,22 @@ in {
       default = true;
       description = lib.mdDoc ''
         Toggles visibility on the Steam server & community lists.
+
         When not set, defaults to true (visible).
         Set to false to make the server private.
+      '';
+    };
+
+    logFile = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      example = "/var/log/valheim-server.log";
+      description = lib.mdDoc ''
+        The path where the server log file will be saved.
+
+        When set, this will redirect all logs from stdout to the specified path.
+        This means that the logs will not be captured by systemd's journal.
+        Leave this option unset to keep console logging enabled.
       '';
     };
 
@@ -236,6 +250,7 @@ in {
                 "-public ${if cfg.public then "1" else "0"}"
               ]
               ++ (lib.lists.optional cfg.crossplay "-crossplay")
+              ++ (lib.lists.optional (cfg.logFile != null) "-logFile \"${cfg.logFile}\"")
         };
       };
     };


### PR DESCRIPTION
New options:
```
-public 1
-logFile /var/lib/valheim/log/valheim-server.log
-preset "hardcore"
```

By default the `public` flag is set to true as per [the docs](https://valheim.com/support/a-guide-to-dedicated-servers/).

I think the `preset` flag is `"normal"` by default, but leaving it out if the user does not specify it is a better idea imo.