### PR TITLE
Update to version 0.219.16

### DIFF
--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
     appId = "896660";
     depotId = "896661";
     manifestId = "7872048626245078252";
-    hash = "sha256-5SfYcWKt9yyziO73mwbEaxS4ZO8ERBc5WXBv1yZndLk=";
+    hash = "sha256-d1UbkdrTzu/TOjzND9F1iG9Jz8a850wtED+Id52qQcI=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.

--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) name;
     appId = "896660";
     depotId = "896661";
-    manifestId = "2352546016341516446";
+    manifestId = "7872048626245078252";
     hash = "sha256-5SfYcWKt9yyziO73mwbEaxS4ZO8ERBc5WXBv1yZndLk=";
   };
 


### PR DESCRIPTION
From what I can find the manifest ID from 0.219.13 isn't downloadable anymore.