### PR TITLE
Add support for extraArgs, Update server version

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -13,6 +13,16 @@ in {
   options.services.valheim = {
     enable = lib.mkEnableOption (lib.mdDoc "Valheim Dedicated Server");
 
+    extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [];
+      example = [
+        "-modifier deathpenalty casual"
+        "-modifier raids none"
+      ];
+      description = lib.mdDoc "List of additional args to pass into valheim server binary. Can be used to add world modifiers";
+    };
+
     serverName = lib.mkOption {
       type = lib.types.str;
       default = "";
@@ -273,6 +283,7 @@ in {
                 "${valheimServerPkg}/bin/valheim-server"
                 "-name \"${cfg.serverName}\""
               ]
+              ++ cfg.extraArgs
               ++ (lib.lists.optional (cfg.worldName != null) "-world \"${cfg.worldName}\"")
               ++ [
                 "-port \"${builtins.toString cfg.port}\""

--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) name;
     appId = "896660";
     depotId = "896661";
-    manifestId = "954348737509367672";
-    hash = "sha256-0OsgfcpljjYOSeaNgpboOSsh/176i4ubBw1WuljEdeY=";
+    manifestId = "7872048626245078252";
+    hash = "sha256-d1UbkdrTzu/TOjzND9F1iG9Jz8a850wtED+Id52qQcI=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.


### PR DESCRIPTION
* Added support for `extraArgs` parameters. This way we can add arbitrary arguments to the binary. My primary use case was to add world modifiers and global keys, which seems to work really well.
* Also updated the manifest to the latest version. For some reason, the previous version was not getting downloaded from the depot.

I'm already using this patch here: https://github.com/kmjayadeep/homelab-iac/blob/253dc1db0abb54979fed0f74bba8c3095df17e3f/nixos-images/valheim/hosts/chillyfries.nix#L25