### PR TITLE
chore: remove references to deprecated nixpkgs builder

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -232,7 +232,7 @@ in {
           '';
 
         serviceConfig = let
-          valheimBepInExFHSEnvWrapper = pkgs.buildFHSUserEnv {
+          valheimBepInExFHSEnvWrapper = pkgs.buildFHSEnv {
             name = "valheim-server";
             runScript = pkgs.writeScript "valheim-server-bepinex-wrapper" ''
               # Whether or not to enable Doorstop. Valid values: TRUE or FALSE

--- a/pkgs/valheim-server/fhsenv.nix
+++ b/pkgs/valheim-server/fhsenv.nix
@@ -1,12 +1,12 @@
 {
-  buildFHSUserEnv,
+  buildFHSEnv,
   writeScript,
   valheim-server-unwrapped,
   steamworks-sdk-redist,
   zlib,
   pulseaudio,
 }:
-buildFHSUserEnv {
+buildFHSEnv {
   name = "valheim-server";
 
   runScript = writeScript "valheim-server-wrapper" ''


### PR DESCRIPTION
Original error `trace: evaluation warning: 'buildFHSUserEnv' has been renamed to 'buildFHSEnv' and will be removed in 25.11`